### PR TITLE
EventParticipation::setStatus should do a strict comparison

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,16 @@
 
     "autoload": {
         "psr-4": {
-            "CalendArt\\": ["src/", "test/"]
+            "CalendArt\\": "src/"
+        }
+    },
+
+    "autoload-dev": {
+        "psr-4": {
+            "CalendArt\\Tests\\": "tests/"
         }
     },
 
     "minimum-stability": "dev",
     "prefer-stable": true
 }
-

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,7 @@
 
     <testsuites>
         <testsuite name="Project Test Suite">
-            <directory>./test</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
 

--- a/src/EventParticipation.php
+++ b/src/EventParticipation.php
@@ -140,7 +140,7 @@ class EventParticipation
      */
     public function setStatus($status)
     {
-        if (!in_array($status, static::getAvailableStatuses())) {
+        if (!in_array($status, static::getAvailableStatuses(), true)) {
             throw new InvalidArgumentException(sprintf('Status not recognized ; Had "%s", expected one of "%s"', $status, implode('", "', static::getAvailableStatuses())));
         }
 

--- a/tests/EventParticipationTest.php
+++ b/tests/EventParticipationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Calendart\Tests;
+use CalendArt\EventParticipation;
+
+/**
+ * Class EventParticipationTest
+ * @package Calendart\Test
+ * @author Manuel Raynaud <manu@raynaud.io>
+ */
+class EventParticipationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetAvailableStatuses()
+    {
+        self::assertSame(
+            [
+                EventParticipation::STATUS_DECLINED,
+                EventParticipation::STATUS_TENTATIVE,
+                EventParticipation::STATUS_ACCEPTED
+            ],
+            EventParticipation::getAvailableStatuses()
+        );
+    }
+
+    /**
+     * @dataProvider statusProvider()
+     */
+    public function testSetValueWithCorrectValue($status)
+    {
+        $event = $this->prophesize("CalendArt\\AbstractEvent");
+        $user = $this->prophesize("CalendArt\\User");
+        $participation = new EventParticipation($event->reveal(), $user->reveal());
+        $participation->setStatus($status);
+    }
+
+    public function statusProvider()
+    {
+        return [
+            [EventParticipation::STATUS_DECLINED],
+            [EventParticipation::STATUS_TENTATIVE],
+            [EventParticipation::STATUS_ACCEPTED]
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetStatusWithInvalidValueShouldThrowAnException()
+    {
+        $event = $this->prophesize("CalendArt\\AbstractEvent");
+        $user = $this->prophesize("CalendArt\\User");
+        $participation = new EventParticipation($event->reveal(), $user->reveal());
+        $participation->setStatus(null);
+    }
+
+}


### PR DESCRIPTION
in `EventParticpation::setStatus` the comparison made is not strict so `0` and `null` will return true while `null` is not an expected value.
